### PR TITLE
Update nav to reflect map & home pages

### DIFF
--- a/src/features/header/index.tsx
+++ b/src/features/header/index.tsx
@@ -3,28 +3,31 @@ import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import SearchIcon from '@mui/icons-material/Search';
-import { Link } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import { IconButton, Link, Menu, MenuItem } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { getLocations } from '../locations/api/locations';
 import { useEffect, useState } from 'react';
 import { Search, SearchIconWrapper, StyledInputBase } from 'components/search/search';
-import { SearchResultsDialog } from 'components';
+import { LinkRouter, SearchResultsDialog } from 'components';
 import { random } from 'lodash';
 import { LocationQueryParams } from '../locations/types';
 import { toast } from 'react-toastify';
 
 export default function SearchAppBar() {
   const notify = () => toast("No results found");
+  const [anchorElNav, setAnchorElNav] = useState<null | HTMLElement>(null);
   const [searchQuery, setSearchQuery] = useState<LocationQueryParams>({search: '', limit: 10})
   const [queryEnabled, setQueryEnabled] = useState<boolean>(false)
   const [searchOpen, setSearchOpen] = useState<boolean>(false)
   // Used to make sure the query is unique if the same params are used
   const [queryId, setQueryId] = useState<number>(random(1, 1000))
+  const pages = ['Home', 'Map'];
 
   const {data} = useQuery(['locations', queryId ,searchQuery], () => getLocations(searchQuery), {
     enabled: queryEnabled,
     onError: (error) => {
-      console.log(error)
+      console.warn(error)
     },
     onSuccess: (data) => {
       if (data.length === 0) {
@@ -57,22 +60,68 @@ export default function SearchAppBar() {
     }
   }, [data])
 
+  const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorElNav(event.currentTarget);
+  };
+
+  const handleCloseNavMenu = () => {
+    setAnchorElNav(null);
+  };
+
   return (
     <>
     <SearchResultsDialog open={searchOpen} onClose={handleClose} searchTerm={searchQuery.search} results={locationData} />
     <Box sx={{ flexGrow: 1 }} id={'search-bar-header'} data-testid={'search-bar-header'}>
       <AppBar position="static" sx={{backgroundColor: 'primary.dark'}}>
-        <Toolbar>
+        <Toolbar disableGutters>
           <Link href="/" underline="none" color="inherit" sx={{ display: 'flex', alignItems: 'center' }}>
             <Typography
               variant="h6"
               noWrap
               component="div"
-              sx={{ display: { xs: 'none', sm: 'block' }, marginRight: '40px' }}
+              sx={{ display: { xs: 'none', sm: 'block' }, marginRight: '40px', marginLeft: '20px' }}
             >
               surfe diem
             </Typography>
           </Link>
+          <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+            <IconButton
+              size="large"
+              aria-label="account of current user"
+              aria-controls="menu-appbar"
+              aria-haspopup="true"
+              onClick={handleOpenNavMenu}
+              color="inherit"
+            >
+              <MenuIcon />
+            </IconButton>
+            <Menu
+              id="menu-appbar"
+              anchorEl={anchorElNav}
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'left',
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'left',
+              }}
+              open={Boolean(anchorElNav)}
+              onClose={handleCloseNavMenu}
+              sx={{
+                display: { xs: 'block', md: 'none' },
+              }}
+            >
+              {pages.map((page) => (
+                <MenuItem key={page} onClick={handleCloseNavMenu}>
+                  <LinkRouter to={`/${page.toLocaleLowerCase()}`} >
+                    <Typography textAlign="center">{page}</Typography>  
+                  </LinkRouter>
+                </MenuItem>
+              ))}
+            </Menu>
+          </Box>
           <Search>
             <SearchIconWrapper>
               <SearchIcon />
@@ -83,6 +132,15 @@ export default function SearchAppBar() {
               inputProps={{ 'aria-label': 'search' }}
             />
           </Search>
+          <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+            {pages.map((page) => (
+              <LinkRouter key={page} to={`/${page.toLocaleLowerCase()}`} underline="none" color="inherit" sx={{ my: 2, color: 'white', display: 'block' }}>
+                <Typography variant="h6" noWrap component="div" sx={{marginRight: "16px"}}>
+                  {page}
+                </Typography>
+              </LinkRouter>
+            ))}
+          </Box>
         </Toolbar>
       </AppBar>
     </Box>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -38,6 +38,11 @@ export const router = createBrowserRouter([
             errorElement: <ErrorPage error={{}} />,
           },
           {
+            path: "/home",
+            element: <Home />,
+            errorElement: <ErrorPage error={{}} />,
+          },
+          {
             path: "location/:locationId",
             element: <LocationsPage />,
             errorElement: <ErrorPage error={{}} />,


### PR DESCRIPTION
Updated the main nav menu to add some items for `/map` & `/home` (which just loads the same component as `/`).

In mobile views, hamburger menu is used to the left of search. Requested by our idiot viewers.