### PR TITLE
add featured spots to home page

### DIFF
--- a/src/features/forecasts/types/index.ts
+++ b/src/features/forecasts/types/index.ts
@@ -13,6 +13,9 @@ export interface ForecastDataHourly {
 export interface ForecastDataDaily {
   daily: {
     time: string[],
-    wave_height_max: number[]
+    wave_height_max?: number[]
+    swell_wave_height_max?: number[]
+    wave_direction_dominant?: number[]
+    wave_period_max?: number[]
   }
 }

--- a/src/features/locations/api/locations.ts
+++ b/src/features/locations/api/locations.ts
@@ -1,7 +1,7 @@
 import { GeoJSON } from '@features/maps/types';
 import {axios} from '../../../lib/axios';
 import {API_ROUTES} from '../../../utils/routing'
-import { BuoyLocation, BuoyLocationLatestObservation} from '../types';
+import { BuoyLocation, BuoyLocationLatestObservation, Spot} from '../types';
 
 type QueryParams = {
   limit?: number;
@@ -21,6 +21,16 @@ type QueryParams = {
  */
 type LatestObservationItem = {
   [key: string]: string
+}
+
+export const getSurfSpots = async (): Promise<Spot[]> => {
+  const response = await axios.get(API_ROUTES.SURF_SPOTS);
+  return response.data;
+}
+
+export const getSurfSpotsGeoJson = async (): Promise<GeoJSON> => {
+  const response = await axios.get(API_ROUTES.SURF_SPOTS_GEOJSON);
+  return response.data;
 }
 
 export const getGeoJsonLocations = (): Promise<GeoJSON> => {

--- a/src/features/locations/spot-summary.tsx
+++ b/src/features/locations/spot-summary.tsx
@@ -1,0 +1,82 @@
+import { LocationOn, Navigation } from "@mui/icons-material"
+import { Card, CardContent, Divider, Typography } from "@mui/material"
+import { Box } from "@mui/system"
+import { useQuery } from "@tanstack/react-query"
+import { getTodaysDate } from "utils/common"
+import { ForecastDataHourly, getOpenMeteoForecastHourly } from ".."
+import { Spot } from "./types"
+import { Loading } from "components"
+import { isEmpty } from "lodash"
+
+export default function SpotSummary (props: Spot) {
+  const {latitude, longitude, name, subregion_name, id} = props
+
+  const {data, isLoading: isHourlyForecastLoading, isError } = useQuery(['forecast_hourly', id], () => getOpenMeteoForecastHourly({
+    latitude: latitude,
+    longitude: longitude,
+    start_date: getTodaysDate(),
+    end_date: getTodaysDate(1)
+  }), {
+    enabled: true
+  })
+
+  function renderLatestObservation(hourlyData: ForecastDataHourly) {
+    if (!hourlyData) return (
+      <p>No data available</p>
+    )
+    return (
+      <>
+        <Typography variant="h3" sx={{marginBottom: "2px"}}>
+          {hourlyData.hourly.wave_height[0].toFixed(1)} {hourlyData.hourly_units.wave_height}
+        </Typography>
+        <Typography sx={{ mb: 1.5 }} color="text">
+          {hourlyData.hourly.wave_period[0].toFixed(0)} {hourlyData.hourly_units.wave_period}
+        </Typography>
+        <Typography sx={{ mb: 1.5 }} color="text">
+          <Navigation
+            sx={{transform: `rotate(${hourlyData.hourly.wave_direction[0] - 180}deg)`
+            }}
+          /> {hourlyData.hourly.wave_direction[0]} {hourlyData.hourly_units.wave_direction}
+        </Typography>
+      </>
+    ) 
+  }
+
+  return (
+    <>
+      {isHourlyForecastLoading ? (
+        <Loading />
+      ) : (
+        <Card key={id} data-testid="location-summary-card"
+          sx={{ 
+            height: "100%",
+            display: "flex",
+            flexDirection: "column"
+          }}
+        >
+          <CardContent>
+            <h2>{name}</h2>
+            <Typography sx={{ mb: 1 }} color="text.secondary">
+              {subregion_name}
+            </Typography>
+            <Typography sx={{ mb: 1 }} color="text.secondary">
+              <LocationOn /> {latitude.toFixed(2)}, {longitude.toFixed(2)}
+            </Typography>
+
+            <Box sx={{ mb: 1 }}>
+              <Divider variant="middle" />
+            </Box>
+            <Box className="current-conditions">
+              {data && !isEmpty(data) && !isError ? (
+                renderLatestObservation(data)
+              ) : (
+                <p>No data available</p>
+              )}
+            </Box>
+          </CardContent>
+        </Card>       
+      )}
+      
+    </>
+  )
+}

--- a/src/features/locations/types/index.d.ts
+++ b/src/features/locations/types/index.d.ts
@@ -1,3 +1,13 @@
+export interface Spot {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  active: boolean;
+  subregion_name: string;
+  timezone: string;
+}
+
 export type LocationQueryParams = {
   search?: string,
   limit?: number

--- a/src/features/maps/mapbox/index.tsx
+++ b/src/features/maps/mapbox/index.tsx
@@ -6,6 +6,7 @@ import './mapbox.css'
 import { Item, LinkRouter } from 'components';
 import { Stack } from '@mui/material';
 import { GeoJSON, GeoJSONProperties } from 'features/maps/types'
+import { DEFAULT_CENTER } from 'utils/constants';
 mapboxgl.accessToken = MAPBOX_API_KEY;
 
 interface MapProps {
@@ -16,8 +17,8 @@ interface MapProps {
 }
 
 export const MapBox = (props: MapProps) => {
-  const [lng, setLng] = useState(props.lat || -122.4376);
-  const [lat, setLat] = useState(props.lng || 37.7577);
+  const [lng, setLng] = useState(props.lat || DEFAULT_CENTER[0]);
+  const [lat, setLat] = useState(props.lng || DEFAULT_CENTER[1]);
   const [zoom, setZoom] = useState(props.zoom || 5);
   const [selectedItem, setSelectedItem] = useState<GeoJSONProperties | null>(null); // [id, name, description]
   const mapContainer = useRef<HTMLDivElement | null>(null);

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,20 +1,26 @@
 import LocationSummary from "@features/locations/summary";
 import {Box, Container, Stack, Typography} from "@mui/material";
 import { useQuery } from "@tanstack/react-query";
-import { getLocations } from "@features/locations/api/locations";
+import { getLocations, getSurfSpots } from "@features/locations/api/locations";
 import { isEmpty } from "lodash";
-import { BuoyLocation } from "@features/locations/types";
+import { BuoyLocation, Spot } from "@features/locations/types";
 import { Item } from "components";
 import BasicSelect from "components/common/basic-select";
 import { useNavigate } from "react-router-dom";
+import { FEATURED_SPOTS } from "utils/constants";
+import SpotSummary from "@features/locations/spot-summary";
 
 
 const Home = () => {
   const navigate = useNavigate();
-  const {data} = useQuery(['locations'], async () => getLocations())
-  const locationsData = data || []
+  const {data: buoys} = useQuery(['locations'], async () => getLocations())
+  const {data: spots} = useQuery(['spots'], async () => getSurfSpots())
+  const buoysData = buoys || []
+  const featuredSpots = spots?.flatMap((spot: Spot) => {
+    return FEATURED_SPOTS.includes(spot.name) ? spot : []
+  }) || []
 
-  function renderLocations(data: BuoyLocation[], n = 3) {
+  function renderBuoyLocations(data: BuoyLocation[], n = 3) {
     if (isEmpty(data)) {
       return (
         <p>loading...</p>
@@ -31,6 +37,19 @@ const Home = () => {
     )
   }
 
+  function renderSpots(data: Spot[], n = 3) {
+    console.log(data)
+    return (
+      <>
+        {data.slice(0, n).map((spot: Spot) => {
+          return (
+            <SpotSummary key={spot.id} {...spot} />   
+          )
+        })}
+      </>
+    )
+  }
+
   function goToBuoyPage(location_id: string) {
     navigate(`/location/${location_id}`)
     return
@@ -39,18 +58,31 @@ const Home = () => {
   return (
     <>
       <Container maxWidth="xl" sx={{ marginTop: '20px', padding: "20px" }}>
-        <Box sx={{maxWidth: {sm: "100%", md: "50%"}}}>
-          {locationsData && locationsData.length > 0 && (
-            <BasicSelect label={"select buoy"} items={locationsData} doOnSelect={goToBuoyPage} />
-          )}
-        </Box>
+      <h1>Latest conditions</h1>
         <Box sx={{ marginTop: "20px", marginBottom: "20px" }}>
-          <Typography variant="h4" sx={{marginBottom: "10px"}}>Latest conditions</Typography>
+          <Typography variant="h5" sx={{marginBottom: "10px"}}>buoys</Typography>
+          <Box sx={{maxWidth: {sm: "100%", md: "50%"}}}>
+            {buoysData && buoysData.length > 0 && (
+              <BasicSelect label={"select buoy"} items={buoysData} doOnSelect={goToBuoyPage} />
+            )}
+          </Box>
           <Item sx={{ bgcolor: 'primary.light', marginTop: "20px"}}>
             <Stack direction={{ xs: 'column', sm: 'column', md: 'row' }} spacing={2}>
-              {data && !isEmpty(data)? (
-                  renderLocations(locationsData, 4)
+              {buoys && !isEmpty(buoys)? (
+                  renderBuoyLocations(buoysData, 4)
               ) : (
+                <p>No data available</p>
+              )}
+            </Stack>
+          </Item>
+        </Box>
+        <Box sx={{ marginTop: "20px", marginBottom: "20px" }}>
+          <Typography variant="h5" sx={{marginBottom: "10px"}}>featured spots</Typography>
+          <Item sx={{ bgcolor: 'primary.light', marginTop: "20px"}}>
+            <Stack direction={{ xs: 'column', sm: 'column', md: 'row' }} spacing={2}>
+              {spots && !isEmpty(spots)? (
+                renderSpots(featuredSpots, 5)
+              ): (
                 <p>No data available</p>
               )}
             </Stack>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,3 +4,6 @@ export const SIG_WAVE_HEIGHT = "Significant wave height is the average height of
 export const DOMINANT_WAVE_PERIOD = "Dominant wave period (seconds) is the period with the maximum wave energy."
 export const AVERAGE_WAVE_PERIOD = "Average wave period (seconds) of all waves during the 20-minute period."
 export const MEAN_WAVE_DIRECTION = "Mean wave direction (degrees) is the direction from which the waves at the dominant period are coming."
+export const DEFAULT_CENTER = [-122.4376, 37.7577]
+export const DEFAULT_SPOTS = ["San Francisco", "Santa Cruz", "Pacifica-San Mateo County", "Monterey", "San Luis Obispo County"] // If no location data, use default sub region spots
+export const FEATURED_SPOTS = ["South Ocean Beach", "Steamer Lane", "Pleasure Point", "Manresa", "Privates"] // If no location data, use these default popular spots in Santa Cruz & pick them out of the response object

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -10,4 +10,6 @@ export const API_ROUTES = {
   FORECAST_URL: `${API_PREFIX}/forecast`,
   TIDES_URL: `${API_PREFIX}/tides`,
   LOCATIONS_GEOJSON: `${API_PREFIX}/locations/geojson`,
+  SURF_SPOTS: `${API_PREFIX}/spots`,
+  SURF_SPOTS_GEOJSON: `${API_PREFIX}/spots/geojson`,
 }


### PR DESCRIPTION
I wrote a lot of code here and wanted to push it out to production early; mostly because it lays the foundation for the rest of the 'surf spots' stuff. Its nice to get it on the homepage as its something interesting to look at. 

This does: 
- adds api clients  & types for spots `/api/v1/spots`
- adds a summary box component for basic on the hour updated swell, direction & period data for a spot based on lat/long subject to the whimsey of our open source marine weather api (I don't trust them completely yet).
- icon designating direction in degrees points in the direction the swell is heading. I thought this was fun.

Next steps:
- location instance page
- put a link on the summary box to the instance page
- add more data. add graphs. add interesting things to look at.