### PR TITLE
fixing hourly forecast returned data

### DIFF
--- a/src/features/locations/spot-summary.tsx
+++ b/src/features/locations/spot-summary.tsx
@@ -20,7 +20,7 @@ export default function SpotSummary (props: Spot) {
     enabled: true
   })
 
-  const forecastStartingIndex = data?.hourly.time.findIndex((item: string) => item === formatIsoNearestHour())
+  const forecastStartingIndex = data?.hourly.time.findIndex((item: string) => item === formatIsoNearestHour(props.timezone))
 
   function renderLatestObservation(hourlyData: ForecastDataHourly, idx: number) {
     if (!hourlyData) return (

--- a/src/features/locations/spot-summary.tsx
+++ b/src/features/locations/spot-summary.tsx
@@ -2,7 +2,7 @@ import { LocationOn, Navigation } from "@mui/icons-material"
 import { Card, CardContent, Divider, Typography } from "@mui/material"
 import { Box } from "@mui/system"
 import { useQuery } from "@tanstack/react-query"
-import { getTodaysDate } from "utils/common"
+import { formatIsoNearestHour, getTodaysDate } from "utils/common"
 import { ForecastDataHourly, getOpenMeteoForecastHourly } from ".."
 import { Spot } from "./types"
 import { Loading } from "components"
@@ -15,28 +15,30 @@ export default function SpotSummary (props: Spot) {
     latitude: latitude,
     longitude: longitude,
     start_date: getTodaysDate(),
-    end_date: getTodaysDate(1)
+    end_date: getTodaysDate()
   }), {
     enabled: true
   })
 
-  function renderLatestObservation(hourlyData: ForecastDataHourly) {
+  const forecastStartingIndex = data?.hourly.time.findIndex((item: string) => item === formatIsoNearestHour())
+
+  function renderLatestObservation(hourlyData: ForecastDataHourly, idx: number) {
     if (!hourlyData) return (
       <p>No data available</p>
     )
     return (
       <>
         <Typography variant="h3" sx={{marginBottom: "2px"}}>
-          {hourlyData.hourly.wave_height[0].toFixed(1)} {hourlyData.hourly_units.wave_height}
+          {hourlyData.hourly.wave_height[idx].toFixed(1)} {hourlyData.hourly_units.wave_height}
         </Typography>
         <Typography sx={{ mb: 1.5 }} color="text">
-          {hourlyData.hourly.wave_period[0].toFixed(0)} {hourlyData.hourly_units.wave_period}
+          {hourlyData.hourly.wave_period[idx].toFixed(0)} {hourlyData.hourly_units.wave_period}
         </Typography>
         <Typography sx={{ mb: 1.5 }} color="text">
           <Navigation
             sx={{transform: `rotate(${hourlyData.hourly.wave_direction[0] - 180}deg)`
             }}
-          /> {hourlyData.hourly.wave_direction[0]} {hourlyData.hourly_units.wave_direction}
+          /> {hourlyData.hourly.wave_direction[idx]} {hourlyData.hourly_units.wave_direction}
         </Typography>
       </>
     ) 
@@ -67,8 +69,8 @@ export default function SpotSummary (props: Spot) {
               <Divider variant="middle" />
             </Box>
             <Box className="current-conditions">
-              {data && !isEmpty(data) && !isError ? (
-                renderLatestObservation(data)
+              {data && forecastStartingIndex && !isEmpty(data) && !isError ? (
+                renderLatestObservation(data, forecastStartingIndex)
               ) : (
                 <p>No data available</p>
               )}

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -38,7 +38,6 @@ const Home = () => {
   }
 
   function renderSpots(data: Spot[], n = 3) {
-    console.log(data)
     return (
       <>
         {data.slice(0, n).map((spot: Spot) => {

--- a/src/pages/locations.tsx
+++ b/src/pages/locations.tsx
@@ -5,7 +5,7 @@ import { LatestReportedForecast } from "@features/forecasts/components/latest_re
 import { getLatestObservation, getLocation } from "@features/locations/api/locations"
 import { getDailyTides } from "@features/tides"
 import { DailyTide } from "@features/tides/components/daily_tide"
-import { Box, Grid, Stack} from "@mui/material"
+import { Box, Container, Grid, Stack} from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
 import { Item, Loading } from "components"
 import { isEmpty } from "lodash"
@@ -14,7 +14,6 @@ import { formatIsoNearestHour, formatLatLong, getTodaysDate } from "utils/common
 import { MarkerF } from "@react-google-maps/api";
 import { Map } from "@features/maps/googlemap"
 import ErrorPage from "./error"
-import PageContainer from "components/common/container"
 
 const LocationsPage = () => {
   const params = useParams()
@@ -62,7 +61,7 @@ const LocationsPage = () => {
   return (
     <div>
       {isLocationError ? <ErrorPage error={error} /> : (
-        <PageContainer>
+        <Container sx={{marginBottom: "20px"}}>
           <h1>{locationData?.name}</h1>
           <Stack direction={{ xs: 'column', sm: 'row' }} marginBottom={'20px'} spacing={2}>
             <Item>{locationData?.description}</Item>
@@ -125,7 +124,7 @@ const LocationsPage = () => {
             <NoData />
           )}
         </Box>
-      </PageContainer>
+      </Container>
       )}
     </div>
   )

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,7 @@
 import { default as dayjs } from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import tz from 'dayjs/plugin/timezone'
+import { DEFAULT_TIMEZONE } from './constants';
 dayjs.extend(utc)
 dayjs.extend(tz)
 
@@ -15,9 +16,9 @@ export const formatNumber = (value: number, n = 2) => {
  * Forecasting times are in this format and we need to match it to get the correct forecast time index.
  * @returns 
  */
-export const formatIsoNearestHour = () => {
+export const formatIsoNearestHour = (timezone = DEFAULT_TIMEZONE) => {
   const now = new Date()
-  return dayjs(now, "America/Los_Angeles").startOf('hour').format('YYYY-MM-DDTHH:mm');
+  return dayjs(now, timezone).startOf('hour').format('YYYY-MM-DDTHH:mm');
 }
 
 export const formatDateTime = (date: string | undefined) => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,3 +7,4 @@ export const MEAN_WAVE_DIRECTION = "Mean wave direction (degrees) is the directi
 export const DEFAULT_CENTER = [-122.4376, 37.7577]
 export const DEFAULT_SPOTS = ["San Francisco", "Santa Cruz", "Pacifica-San Mateo County", "Monterey", "San Luis Obispo County"] // If no location data, use default sub region spots
 export const FEATURED_SPOTS = ["South Ocean Beach", "Steamer Lane", "Pleasure Point", "Manresa", "Privates"] // If no location data, use these default popular spots in Santa Cruz & pick them out of the response object
+export const DEFAULT_TIMEZONE = "America/Los_Angeles"


### PR DESCRIPTION
The data thats returned from the hourly forecast API call is indexed over 24 hours - this component was always using index 0 rather than the index of the current hour. We also don't need an end date as we are just getting one day of "hourly" data.

Fixed all this - we already have a function that calculates nearest hour & I changed it to accept a timezone.