### PR TITLE
Add spot page

### DIFF
--- a/src/features/locations/api/locations.ts
+++ b/src/features/locations/api/locations.ts
@@ -28,6 +28,14 @@ export const getSurfSpots = async (): Promise<Spot[]> => {
   return response.data;
 }
 
+export const getSurfSpot = async (id: string | number | undefined): Promise<Spot> => {
+  return axios.get(`${API_ROUTES.SURF_SPOTS}/${id}`)
+    .then((response) => {
+      return response.data
+    })
+  
+}
+
 export const getSurfSpotsGeoJson = async (): Promise<GeoJSON> => {
   const response = await axios.get(API_ROUTES.SURF_SPOTS_GEOJSON);
   return response.data;

--- a/src/features/locations/spot-summary.tsx
+++ b/src/features/locations/spot-summary.tsx
@@ -1,5 +1,5 @@
 import { LocationOn, Navigation } from "@mui/icons-material"
-import { Card, CardContent, Divider, Typography } from "@mui/material"
+import { Button, Card, CardActions, CardContent, Divider, Typography } from "@mui/material"
 import { Box } from "@mui/system"
 import { useQuery } from "@tanstack/react-query"
 import { formatIsoNearestHour, getTodaysDate } from "utils/common"
@@ -7,6 +7,7 @@ import { ForecastDataHourly, getOpenMeteoForecastHourly } from ".."
 import { Spot } from "./types"
 import { Loading } from "components"
 import { isEmpty } from "lodash"
+import { Link } from 'react-router-dom';
 
 export default function SpotSummary (props: Spot) {
   const {latitude, longitude, name, subregion_name, id} = props
@@ -76,6 +77,11 @@ export default function SpotSummary (props: Spot) {
               )}
             </Box>
           </CardContent>
+          <CardActions disableSpacing sx={{ mt: "auto" }}>
+            <Button color="secondary" component={Link} to={`/spot/${id}`}>
+              View spot
+            </Button>
+          </CardActions>
         </Card>       
       )}
       

--- a/src/features/tides/api/tides.ts
+++ b/src/features/tides/api/tides.ts
@@ -4,6 +4,8 @@ import { API_ROUTES } from "utils/routing";
 // TODO: TBD params for more specific queries
 interface TidesQueryParams {
   station?: string;
+  lat?: number;
+  lng?: number;
 }
 
 export interface TidesDataDaily {
@@ -12,6 +14,21 @@ export interface TidesDataDaily {
     v: number;
     type: string;
   }[];
+}
+
+export interface TideStationMeta {
+  station_id: string;
+  distance: number;
+  latitude: number;
+  longitude: number;
+}
+
+export const getClostestTideStation = (params: TidesQueryParams): Promise<TideStationMeta> => {
+  return axios.get(API_ROUTES.TIDES_CLOSEST_STATION_URL, {
+    params: params
+  }).then((response) => {
+    return response.data;
+  })
 }
 
 export const getDailyTides = (params: TidesQueryParams): Promise<TidesDataDaily> => {

--- a/src/pages/error.tsx
+++ b/src/pages/error.tsx
@@ -11,6 +11,8 @@ export default function ErrorPage(props: ErrorPageProps) {
    
   const error = props.error
 
+  console.log(error)
+
   return (
     <Container maxWidth="xl" sx={{ height: '100vh', marginTop: '20px', textAlign: 'center' }}>
       <div id="error-page">

--- a/src/pages/spots.tsx
+++ b/src/pages/spots.tsx
@@ -1,0 +1,95 @@
+import { getSurfSpot } from "@features/locations/api/locations"
+import { Box, Grid, Stack } from "@mui/material"
+import { useQuery } from "@tanstack/react-query"
+import { useParams } from "react-router-dom"
+import ErrorPage from "./error"
+import { Item, Loading } from "components"
+import { getClostestTideStation, getDailyTides } from "@features/tides"
+import { getOpenMeteoForecastHourly } from "@features/forecasts"
+import { formatIsoNearestHour, getTodaysDate } from "utils/common"
+import { DailyTide } from "@features/tides/components/daily_tide"
+import { CurrentHourForecast } from "@features/forecasts/components/current_hour_forecast"
+import { Map } from "@features/maps/googlemap"
+import { isEmpty } from "lodash"
+import { MarkerF } from "@react-google-maps/api"
+import PageContainer from "components/common/container"
+
+const SpotsPage = () => {
+  const params = useParams()
+  const { spotId } = params
+
+  const {data: spot, isError, error} = useQuery(
+    ['spots', spotId],
+    () => getSurfSpot(spotId)
+  )
+
+  const {data: tideStationData} = useQuery(['tide_station'], () => getClostestTideStation({lat: spot?.latitude, lng: spot?.longitude}), {
+    enabled: !!spot?.latitude
+  })
+
+  const {data: tideData, isLoading: isTideDataLoading} = useQuery(['latest_tides', params], () => getDailyTides({ station: tideStationData?.station_id}), {
+    enabled: !!tideStationData?.station_id
+  })
+
+  const {data: forecastDataHourly, isLoading: isHourlyForecastLoading } = useQuery(['forecast_hourly'], () => getOpenMeteoForecastHourly({
+    latitude: spot!.latitude,
+    longitude: spot!.longitude,
+    start_date: getTodaysDate()
+  }), {
+    enabled: !!spot?.name
+  })
+
+  const forecastStartingIndex = forecastDataHourly?.hourly.time.findIndex((item: string) => item === formatIsoNearestHour(spot?.timezone))
+
+  return (
+    <>
+      {isError && <ErrorPage error={error} />}
+      {spot && (
+        <PageContainer>
+          <h1>{spot.name}</h1>
+          <Stack direction={{ xs: 'column', sm: 'row' }} marginBottom={'20px'} spacing={2}>
+            <Item>{spot.latitude.toFixed(2)}, {spot.longitude.toFixed(2)}</Item>
+            <Item>{spot.subregion_name}</Item>
+            <Item>{spot.timezone}</Item>
+          </Stack>
+
+          { !isEmpty(spot) && (
+            <>
+              <Map
+                center={{lat: spot.latitude, lng: spot.longitude}}
+                zoom={8}
+                options={{disableDefaultUI: true}}
+              >
+                <MarkerF position={{lat: spot.latitude, lng: spot.longitude}} />
+              </Map>
+            </>
+          )}
+
+          <Box>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={12} md={3} lg={3}>
+                <h2>Current forecast</h2>
+                { isHourlyForecastLoading ? (
+                  <Loading />
+                ) : (
+                  <CurrentHourForecast forecast={forecastDataHourly} idx={forecastStartingIndex} />
+                )}
+              </Grid>
+
+              <Grid item xs={12} sm={12} md={3} lg={3}>
+                <h2>Tide</h2>
+                {isTideDataLoading ? (
+                  <Loading />
+                ) : tideData && (
+                  <DailyTide {...tideData} />
+                )}
+              </Grid>
+            </Grid>
+          </Box>
+        </PageContainer>
+      )}
+    </>
+  )
+}
+
+export default SpotsPage

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,8 +6,11 @@ import { MAINTENANCE_MODE } from "config";
 import LocationsPage from "pages/locations";
 import MapPage from "pages/map";
 import { AppWrapper } from "./wrapper";
+import SpotsPage from "pages/spots";
 
 const isMaintenanceMode = MAINTENANCE_MODE === 'true' ? true : false;
+
+const DEFAULT_MESSAGE = {message: "Cannot load page. Please try again."}
 
 export const router = createBrowserRouter([
   {
@@ -28,7 +31,12 @@ export const router = createBrowserRouter([
           {
             path: "location/:locationId",
             element: <LocationsPage />,
-            errorElement: <ErrorPage error={{}} />,
+            errorElement: <ErrorPage error={DEFAULT_MESSAGE} />,
+          },
+          {
+            path: "spot/:spotId",
+            element: <SpotsPage />,
+            errorElement: <ErrorPage error={DEFAULT_MESSAGE} />,
           },
           {
             path: "map",

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -9,6 +9,7 @@ export const API_ROUTES = {
   POINTS_URL: `/points`,
   FORECAST_URL: `${API_PREFIX}/forecast`,
   TIDES_URL: `${API_PREFIX}/tides`,
+  TIDES_CLOSEST_STATION_URL: `${API_PREFIX}/tides/find_closest`,
   LOCATIONS_GEOJSON: `${API_PREFIX}/locations/geojson`,
   SURF_SPOTS: `${API_PREFIX}/spots`,
   SURF_SPOTS_GEOJSON: `${API_PREFIX}/spots/geojson`,


### PR DESCRIPTION
Adds `/spot/{id}` page with basic data; forecast, tides, location lat/lng, etc

Home page cards link to their respective spot pages. There are hundreds of data points now, but no way to get to them which is fine and out of scope of this PR.

Going to open another feature req to add charting to this page. Home page will also need a selector and search will need to integrate spot data into its search (can still use name field probably).