### PR TITLE
Refactor search to include spots

### DIFF
--- a/src/components/search/search-results.tsx
+++ b/src/components/search/search-results.tsx
@@ -3,18 +3,18 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
-import { BuoyLocation } from '@features/locations/types';
 import { useNavigate } from "react-router-dom";
-import { Support } from '@mui/icons-material';
+import { LocationOn, Support } from '@mui/icons-material';
+import { BuoyLocation, Spot } from '@features/locations/types';
 
-export interface SimpleDialogProps {
-  results?: BuoyLocation[];
+export interface SimpleDialogProps<T> {
+  results?: Record<string, T>[];
   open: boolean;
   searchTerm?: string;
   onClose: () => void;
 }
 
-export function SearchResultsDialog(props: SimpleDialogProps) {
+export function SearchResultsDialog<T>(props: SimpleDialogProps<T>) {
   const navigate = useNavigate();
   const { onClose, searchTerm, open, results } = props;
 
@@ -22,20 +22,36 @@ export function SearchResultsDialog(props: SimpleDialogProps) {
     onClose();
   };
 
-  const handleListItemClick = (value: string) => {
+  const handleListItemClick = (href: string) => {
     onClose();
-    navigate(`/location/${value}`)
+    navigate(href)
   };
+
+  const renderResultItem = (item: Spot | BuoyLocation) => {
+    if ('location_id' in item) {
+      return (
+        <ListItem disableGutters key={item.location_id}>
+          <ListItemButton onClick={() => handleListItemClick(`/location/${item.location_id}`)}>
+            <Support sx={{marginRight: '10px'}} /><ListItemText primary={item.name} />
+          </ListItemButton>
+        </ListItem>
+      )
+    } else {
+      return (
+        <ListItem disableGutters key={item.id}>
+          <ListItemButton onClick={() => handleListItemClick(`/spot/${item.id}`)}>
+            <LocationOn sx={{marginRight: '10px'}} /><ListItemText primary={item.name} />
+          </ListItemButton>
+        </ListItem>
+      )
+    }
+  }
 
   return (
     <Dialog onClose={handleClose} open={open}>
       <DialogTitle>Search results for "{searchTerm}"</DialogTitle>
-      {results && results.length && results.map((location) => (
-        <ListItem disableGutters key={location.id}>
-          <ListItemButton onClick={() => handleListItemClick(location.location_id)}>
-            <Support sx={{marginRight: '10px'}} /><ListItemText primary={location.name} />
-          </ListItemButton>
-        </ListItem>
+      {results && results.length && results.map((item) => (
+        renderResultItem(item as unknown as Spot | BuoyLocation)
       ))}
     </Dialog>
   );

--- a/src/features/header/index.tsx
+++ b/src/features/header/index.tsx
@@ -6,25 +6,26 @@ import SearchIcon from '@mui/icons-material/Search';
 import MenuIcon from '@mui/icons-material/Menu';
 import { IconButton, Link, Menu, MenuItem } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { getLocations } from '../locations/api/locations';
+import { getSearchResults } from '../locations/api/locations';
 import { useEffect, useState } from 'react';
 import { Search, SearchIconWrapper, StyledInputBase } from 'components/search/search';
 import { LinkRouter, SearchResultsDialog } from 'components';
 import { random } from 'lodash';
-import { LocationQueryParams } from '../locations/types';
+import { SearchQueryParams } from '../locations/types';
 import { toast } from 'react-toastify';
 
 export default function SearchAppBar() {
   const notify = () => toast("No results found");
   const [anchorElNav, setAnchorElNav] = useState<null | HTMLElement>(null);
-  const [searchQuery, setSearchQuery] = useState<LocationQueryParams>({search: '', limit: 10})
+  const [searchQuery, setSearchQuery] = useState<SearchQueryParams>({q: '', limit: 10})
   const [queryEnabled, setQueryEnabled] = useState<boolean>(false)
   const [searchOpen, setSearchOpen] = useState<boolean>(false)
   // Used to make sure the query is unique if the same params are used
   const [queryId, setQueryId] = useState<number>(random(1, 1000))
   const pages = ['Home', 'Map'];
 
-  const {data} = useQuery(['locations', queryId ,searchQuery], () => getLocations(searchQuery), {
+
+  const {data: searchResultData} = useQuery(['search', queryId ,searchQuery], () => getSearchResults(searchQuery), {
     enabled: queryEnabled,
     onError: (error) => {
       console.warn(error)
@@ -36,12 +37,12 @@ export default function SearchAppBar() {
     }
   })
 
-  const locationData = data || []
+  // const locationData = data || []
 
   const handleSubmit = (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     if (e.key === "Enter") {
       const query = e.currentTarget.value
-      setSearchQuery({search: query, limit: 10})
+      setSearchQuery({q: query, limit: 10})
       setQueryId(random(1, 1000))
       setQueryEnabled(true)
     }
@@ -53,12 +54,12 @@ export default function SearchAppBar() {
   };
 
   useEffect(() => {
-    if (data?.length) {
+    if (searchResultData?.length) {
       setSearchOpen(true)
     } else {
       setSearchOpen(false)
     }
-  }, [data])
+  }, [searchResultData])
 
   const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElNav(event.currentTarget);
@@ -70,7 +71,7 @@ export default function SearchAppBar() {
 
   return (
     <>
-    <SearchResultsDialog open={searchOpen} onClose={handleClose} searchTerm={searchQuery.search} results={locationData} />
+    <SearchResultsDialog open={searchOpen} onClose={handleClose} searchTerm={searchQuery.q} results={searchResultData} />
     <Box sx={{ flexGrow: 1 }} id={'search-bar-header'} data-testid={'search-bar-header'}>
       <AppBar position="static" sx={{backgroundColor: 'primary.dark'}}>
         <Toolbar disableGutters>

--- a/src/features/locations/api/locations.ts
+++ b/src/features/locations/api/locations.ts
@@ -8,6 +8,11 @@ type QueryParams = {
   search?: string;
 }
 
+type SearchParams = {
+  q: string;
+  limit?: number;
+}
+
 /**
  * Type for observations
  * Sample response:
@@ -23,9 +28,20 @@ type LatestObservationItem = {
   [key: string]: string
 }
 
-export const getSurfSpots = async (): Promise<Spot[]> => {
-  const response = await axios.get(API_ROUTES.SURF_SPOTS);
-  return response.data;
+export const getSearchResults = async <T>(params: SearchParams): Promise<Record<string, T>[]> => {
+  return axios.get(API_ROUTES.SEARCH, {
+    params: params
+  }).then((response) => {
+    return response.data;
+  })
+}
+
+export const getSurfSpots = async (params?: QueryParams): Promise<Spot[]> => {
+  return axios.get(API_ROUTES.SURF_SPOTS, {
+    params: params
+  }).then((response) => {
+    return response.data;
+  })
 }
 
 export const getSurfSpot = async (id: string | number | undefined): Promise<Spot> => {

--- a/src/features/locations/types/index.d.ts
+++ b/src/features/locations/types/index.d.ts
@@ -13,6 +13,11 @@ export type LocationQueryParams = {
   limit?: number
 }
 
+export type SearchQueryParams = {
+  q: string,
+  limit?: number
+}
+
 export interface BuoyLocation {
   name: string,
   url: string,

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -13,4 +13,5 @@ export const API_ROUTES = {
   LOCATIONS_GEOJSON: `${API_PREFIX}/locations/geojson`,
   SURF_SPOTS: `${API_PREFIX}/spots`,
   SURF_SPOTS_GEOJSON: `${API_PREFIX}/spots/geojson`,
+  SEARCH: `${API_PREFIX}/search`,
 }


### PR DESCRIPTION
This PR refactors the search components to include Spots in the list of results. This is done less by the front end and more via the new endpoint I added to the API. Front end components are still dumb they just have to display different HTML for buoy vs spot now. 