### PR TITLE
Add stubbed out weather component

### DIFF
--- a/src/features/weather/api/index.ts
+++ b/src/features/weather/api/index.ts
@@ -1,0 +1,14 @@
+import { API_ROUTES } from 'utils/routing';
+import {axios} from '../../../lib/axios';
+import { WeatherParams } from '../types';
+
+// TODO: type for the response, add to types/index.ts
+// the Record<string, T>[] is a placeholder for now and kinda just generic and better than using 'any'
+
+export const getCurrentWeather = <T>(params: WeatherParams): Promise<Record<string, T>[]> => {
+  return axios.get(API_ROUTES.WEATHER, {
+    params: params
+  }).then((response) => {
+    return response.data;
+  })
+}

--- a/src/features/weather/components/current_weather.tsx
+++ b/src/features/weather/components/current_weather.tsx
@@ -1,0 +1,13 @@
+
+interface CurrentWeatherProps {
+  currentWeather: Record<string, unknown>
+}
+
+export const CurrentWeather = (props: CurrentWeatherProps) => {
+  console.log(props)
+  return (
+    <>
+      {/* <div>Current Weather</div> */}
+    </>
+  )
+}

--- a/src/features/weather/types/index.ts
+++ b/src/features/weather/types/index.ts
@@ -1,0 +1,4 @@
+export type WeatherParams = {
+  lat: number;
+  lng: number;
+}

--- a/src/pages/spots.tsx
+++ b/src/pages/spots.tsx
@@ -12,6 +12,8 @@ import { CurrentHourForecast } from "@features/forecasts/components/current_hour
 import { isEmpty } from "lodash"
 import WaveChart from "@features/charts/wave-height"
 import MapBoxSingle from "@features/maps/mapbox/single-instance"
+import { CurrentWeather } from "@features/weather/components/current_weather"
+import { getCurrentWeather } from "@features/weather/api"
 
 const SpotsPage = () => {
   const params = useParams()
@@ -38,6 +40,12 @@ const SpotsPage = () => {
     enabled: !!spot?.name
   })
 
+  const {data: currentWeather} = useQuery(['current_weather'], () => getCurrentWeather({lat: spot!.latitude, lng: spot!.longitude}), {
+    enabled: !!spot?.name
+  })
+
+  console.log(currentWeather)
+
   const forecastStartingIndex = forecastDataHourly?.hourly.time.findIndex((item: string) => item === formatIsoNearestHour(spot?.timezone))
 
   return (
@@ -46,6 +54,7 @@ const SpotsPage = () => {
       {spot && (
         <Container sx={{marginBottom: "20px"}}>
           <h1>{spot.name}</h1>
+          <CurrentWeather currentWeather={{}} />
           <Stack direction={{ xs: 'column', sm: 'row' }} marginBottom={'20px'} spacing={2}>
             <Item>{spot.latitude.toFixed(2)}, {spot.longitude.toFixed(2)}</Item>
             <Item>{spot.subregion_name}</Item>

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -14,4 +14,5 @@ export const API_ROUTES = {
   SURF_SPOTS: `${API_PREFIX}/spots`,
   SURF_SPOTS_GEOJSON: `${API_PREFIX}/spots/geojson`,
   SEARCH: `${API_PREFIX}/search`,
+  WEATHER: `${API_PREFIX}/weather`,
 }


### PR DESCRIPTION
Added the foundation stuff for the weather component.
- component is stubbed out for now, and doesn't return any data
- needs types, template jsx/html & data props passed to it

Can render it on the spot page (src/pages/spots.tsx) around the header:

![Screen Shot 2024-02-21 at 10 30 01 AM](https://github.com/crubio/surfe-diem-app/assets/1584479/9e7b3861-3242-401d-ac11-a97b9492ed85)

@wondersloth take a crack at making the component if you want to. I'll merge this to main and you can just create a new PR, probably easiest.