### PR TITLE
Add nearest buoys to surf spot page

### DIFF
--- a/src/features/locations/api/locations.ts
+++ b/src/features/locations/api/locations.ts
@@ -1,7 +1,7 @@
 import { GeoJSON } from '@features/maps/types';
 import {axios} from '../../../lib/axios';
 import {API_ROUTES} from '../../../utils/routing'
-import { BuoyLocation, BuoyLocationLatestObservation, Spot} from '../types';
+import { BuoyLocation, BuoyLocationLatestObservation, BuoyNearestType, Spot} from '../types';
 
 type QueryParams = {
   limit?: number;
@@ -86,6 +86,17 @@ export const getLocations = (params?: QueryParams): Promise<BuoyLocation[]> => {
 
 export const getLocation = (id: string | undefined): Promise<BuoyLocation> => {
   return axios.get(`${API_ROUTES.LOCATIONS}/${id}`).then((response) => {
+    return response.data;
+  })
+}
+
+export const getLocationBuoyNearby = (lat: number, lng: number): Promise<BuoyNearestType[]> => {
+  return axios.get(`${API_ROUTES.LOCATIONS}/find_closest`, {
+    params: {
+      lat: lat,
+      lng: lng
+    }
+  }).then((response) =>{
     return response.data;
   })
 }

--- a/src/features/locations/nearby-buoys.tsx
+++ b/src/features/locations/nearby-buoys.tsx
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import { getLocationBuoyNearby } from "./api/locations";
+import { Item, LinkRouter } from "components";
+import { Stack, Typography } from "@mui/material";
+import { BuoyNearestType } from "./types";
+import { goToBuoyPage } from "utils/routing";
+
+type Props = {
+    latitude: number;
+    longitude: number;
+    numToRender?: number;
+}
+
+const BuoyDisplay = ({ children, ...props }: BuoyNearestType & { children?: React.ReactNode }) => {
+    return (
+        <Item sx={{maxWidth: "fit-content", padding: "10px"}}>
+            <Typography variant="body1" component="div">
+                <LinkRouter to={goToBuoyPage(props.location_id)} style={{textDecoration:"none"}}>{props.name}</LinkRouter>
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+                {props.description}
+            </Typography>
+            {children}
+        </Item>
+    )
+}
+
+export const NearbyBuoys = (props: Props) => {
+    const {latitude, longitude} = props;
+    const {data: nearbyBuoys} = useQuery([`get-nearest-buoy-${latitude}-${longitude}`], () => getLocationBuoyNearby(latitude, longitude));
+
+    return (
+        <>
+            {nearbyBuoys ? (
+                <>
+                    <h2>Nearby Buoys</h2>
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{marginBottom:"20px"}}>
+                        {nearbyBuoys.slice(0, props.numToRender || 3).map((buoy) => {
+                            return (
+                                <BuoyDisplay {...buoy} key={buoy.location_id} />
+                            )}
+                        )}
+                    </Stack>
+                </>
+            ): null}
+        </>
+    );
+}

--- a/src/features/locations/types/index.d.ts
+++ b/src/features/locations/types/index.d.ts
@@ -33,6 +33,17 @@ export interface BuoyLocation {
   station_id?: string,
 }
 
+export type BuoyNearestType = {
+  description: string
+  distance: string
+  latitude: string
+  location: string
+  location_id: string
+  longitude: string
+  name: string
+  url: string
+}
+
 export interface BuoyLocations {
   locations: Location[]
 }

--- a/src/pages/locations.tsx
+++ b/src/pages/locations.tsx
@@ -5,7 +5,7 @@ import { LatestReportedForecast } from "@features/forecasts/components/latest_re
 import { getLatestObservation, getLocation } from "@features/locations/api/locations"
 import { getDailyTides } from "@features/tides"
 import { DailyTide } from "@features/tides/components/daily_tide"
-import { Box, Container, Grid, Stack} from "@mui/material"
+import { Box, Container, Grid, Link, Stack} from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
 import { Item, Loading } from "components"
 import { isEmpty } from "lodash"
@@ -65,6 +65,7 @@ const LocationsPage = () => {
           <Stack direction={{ xs: 'column', sm: 'row' }} marginBottom={'20px'} spacing={2}>
             <Item>{locationData?.description}</Item>
             <Item>{locationData?.location?.split("(")[0]}</Item>
+            <Item><Link href={locationData?.url} target="_blank">more info</Link></Item>
           </Stack>
           { locationData?.location && latLong[0] && (
             <>

--- a/src/pages/spots.tsx
+++ b/src/pages/spots.tsx
@@ -14,6 +14,7 @@ import WaveChart from "@features/charts/wave-height"
 import MapBoxSingle from "@features/maps/mapbox/single-instance"
 import { CurrentWeather } from "@features/weather/components/current_weather"
 import { getCurrentWeather } from "@features/weather/api"
+import { NearbyBuoys } from "@features/locations/nearby-buoys"
 
 const SpotsPage = () => {
   const params = useParams()
@@ -49,7 +50,7 @@ const SpotsPage = () => {
   return (
     <>
       {isError && <ErrorPage error={error} />}
-      {spot && (
+      {spot ? (
         <Container sx={{marginBottom: "20px"}}>
           <h1>{spot.name}</h1>
           <Stack direction={{ xs: 'column', sm: 'row' }} marginBottom={'20px'} spacing={2}>
@@ -59,6 +60,9 @@ const SpotsPage = () => {
           </Stack>
           {currentWeather && (
             <CurrentWeather currentWeather={currentWeather} isLoading={isWeatherLoading}/>
+          )}
+          {spot && spot.latitude && spot.longitude && (
+            <NearbyBuoys latitude={spot.latitude} longitude={spot.longitude} />
           )}
           { !isEmpty(spot) && (
             <>
@@ -97,7 +101,7 @@ const SpotsPage = () => {
             </Box>
           }
         </Container>
-      )}
+      ): null}
     </>
   )
 }


### PR DESCRIPTION
Add components & API clients for finding nearest buoys for a given surf spot. Uses the `{{URL}}api/v1/locations/find_closest?lat=36.9546808252654&lng=-121.97234` endpoint for example.