### PR TITLE
bug fixes related to errors thrown from toFixed method on daily forecast

### DIFF
--- a/src/features/forecasts/components/daily_forecast.tsx
+++ b/src/features/forecasts/components/daily_forecast.tsx
@@ -13,7 +13,7 @@ export const DailyForecast = (props: DailyForecastProps) => {
   const dash: JSX.Element = (<code>&#8212;</code>)
 
   function renderForecast(data: ForecastDataDaily) {
-    if (!data || isEmpty(data)) return
+    // if (!data || isEmpty(data)) return
     const result = []
     for(let i = 0; i < data.daily.time.length; i++) {
       result.push(
@@ -30,7 +30,9 @@ export const DailyForecast = (props: DailyForecastProps) => {
 
   return (
     <>
-      {renderForecast(forecast)}
+      {forecast || !isEmpty(forecast) ? (
+        renderForecast(forecast)
+      ) : null}
     </>
   )
 }

--- a/src/features/locations/spot-summary.tsx
+++ b/src/features/locations/spot-summary.tsx
@@ -27,7 +27,7 @@ export default function SpotSummary (props: Spot) {
     if (!hourlyData) return (
       <p>No data available</p>
     )
-    return (
+    return ( !isEmpty(hourlyData) ? (
       <>
         <Typography variant="h3" sx={{marginBottom: "2px"}}>
           {hourlyData.hourly.swell_wave_height[idx].toFixed(1)} {hourlyData.hourly_units.swell_wave_height}
@@ -42,7 +42,7 @@ export default function SpotSummary (props: Spot) {
           /> {hourlyData.hourly.swell_wave_direction[idx]} {hourlyData.hourly_units.swell_wave_direction}
         </Typography>
       </>
-    ) 
+    ) : null)
   }
 
   return (


### PR DESCRIPTION
`/spot` page was throwing an error when `toFixed` method was called on an object that didn't exist. 