### PR TITLE
Implement `getCurrentForecast` endpoint

### DIFF
--- a/src/features/forecasts/api/forecast.ts
+++ b/src/features/forecasts/api/forecast.ts
@@ -1,6 +1,12 @@
-import { ForecastDataDaily, ForecastDataHourly } from '..';
+import { ForecastDataCurrent, ForecastDataDaily, ForecastDataHourly } from '..';
 import {axios} from '../../../lib/axios';
 import {API_ROUTES} from '../../../utils/routing'
+
+export enum ForecastTypesCurrent {
+  SWELL_WAVE_HEIGHT = "swell_wave_height",
+  SWELL_WAVE_DIRECTION = "swell_wave_direction",
+  SWELL_WAVE_PERIOD = "swell_wave_period",
+}
 
 export enum ForecastTypesHourly {
   WAVE_HEIGHT = "wave_height",
@@ -25,6 +31,7 @@ type ForecastQueryParams = {
   longitude: number;
   hourly?: string,
   daily?: string,
+  current?: string,
   forecast_days?: number,
   start_date?: string, // e.g., YYYY-MM-DD (2021-01-01)
   end_date?: string,  // e.g., YYYY-MM-DD (2021-01-01)
@@ -34,7 +41,9 @@ const hourlyParams = ForecastTypesHourly.SWELL_WAVE_HEIGHT + "," + ForecastTypes
 
 const dailyParams = ForecastTypesDaily.SWELL_WAVE_HEIGHT + "," + ForecastTypesDaily.SWELL_WAVE_DIRECTION + "," + ForecastTypesDaily.SWELL_WAVE_PERIOD
 
-export const getOpenMeteoForecastHourly = (params: ForecastQueryParams): Promise<ForecastDataHourly> => {
+const currentParams = hourlyParams
+
+export const getForecastHourly = (params: ForecastQueryParams): Promise<ForecastDataHourly> => {
   params['hourly'] = hourlyParams
   return axios.get(API_ROUTES.FORECAST_URL, {
     params: params
@@ -43,12 +52,21 @@ export const getOpenMeteoForecastHourly = (params: ForecastQueryParams): Promise
   })
 }
 
-export const getOpenMeteoForecastDaily = (params: ForecastQueryParams): Promise<ForecastDataDaily> => {
+export const getForecastDaily = (params: ForecastQueryParams): Promise<ForecastDataDaily> => {
   params['daily'] = dailyParams
   return axios.get(API_ROUTES.FORECAST_URL, {
     params: params
   }).then((response) => {
     return response.data;
+  })
+}
+
+export const getForecastCurrent = (params: ForecastQueryParams): Promise<ForecastDataCurrent> => {
+  params['current'] = currentParams
+  return axios.get(API_ROUTES.FORECAST_URL, {
+    params: params
+  }).then((response) => {
+    return response.data
   })
 }
 

--- a/src/features/forecasts/components/current_forecast.tsx
+++ b/src/features/forecasts/components/current_forecast.tsx
@@ -1,0 +1,43 @@
+import { isEmpty } from "lodash"
+import { ForecastDataCurrent } from ".."
+import { Box, Divider, Stack, Typography } from "@mui/material"
+import { formatDateWeekday, formatNumber } from "utils/common"
+import { Item } from "components"
+import { NoData } from "@features/cards/no_data"
+
+export interface CurrentForecastProps {
+  forecast: ForecastDataCurrent
+}
+
+export const CurrentForecast = (props: CurrentForecastProps) => {
+  const {forecast} = props
+  if (!forecast || isEmpty(forecast)) return <NoData />
+
+  return (
+    <Item>
+      <Typography sx={{marginBottom: 2}} variant="subtitle2" color={"text.secondary"}>
+        {formatDateWeekday(forecast.current.time)}
+      </Typography>
+      <Stack direction="row" spacing={2}>
+        <Stack direction="column" spacing={2}>
+          <Typography variant="subtitle2" color={"text.secondary"}>swell height</Typography>
+          <Typography variant="h3" sx={{marginBottom: "2px"}}>{formatNumber(forecast.current.swell_wave_height, 1)}{forecast.current_units.swell_wave_height}</Typography>
+        </Stack>
+        <Divider orientation="vertical" flexItem />
+        <Stack direction="column" spacing={2}>
+          <Box>
+            <Typography 
+              variant="subtitle2" 
+              color={"text.secondary"}
+            >
+              {"swell direction"}
+            </Typography>{forecast.current.swell_wave_direction}{forecast.current_units.swell_wave_direction}
+          </Box>
+          <Box>
+            <Typography variant="subtitle2" color={"text.secondary"}>swell period</Typography>{formatNumber(forecast.current.swell_wave_period, 0)}{forecast.current_units.swell_wave_period}
+          </Box>
+        </Stack>
+      </Stack>
+    </Item>
+  )
+}

--- a/src/features/forecasts/types/index.ts
+++ b/src/features/forecasts/types/index.ts
@@ -24,3 +24,16 @@ export interface ForecastDataDaily {
     swell_wave_period_max: number[]
   }
 }
+
+export interface ForecastDataCurrent {
+  current: {
+    time: string,
+    interval: number,
+    swell_wave_height: number,
+    swell_wave_direction: number,
+    swell_wave_period: number
+  },
+  current_units: {
+    [key: string]: string
+  }
+}

--- a/src/features/header/index.tsx
+++ b/src/features/header/index.tsx
@@ -130,8 +130,8 @@ export default function SearchAppBar() {
                 display: { xs: 'block', md: 'none' },
               }}
             >
-              {pages.map((page) => (
-                <MenuItem key={page} onClick={handleCloseNavMenu}>
+              {pages.map((page, idx) => (
+                <MenuItem key={idx} onClick={handleCloseNavMenu}>
                   <LinkRouter to={`/${page.toLocaleLowerCase()}`} >
                     <Typography textAlign="center">{page}</Typography>  
                   </LinkRouter>

--- a/src/features/locations/spot-summary.tsx
+++ b/src/features/locations/spot-summary.tsx
@@ -3,7 +3,7 @@ import { Button, Card, CardActions, CardContent, Divider, Typography } from "@mu
 import { Box } from "@mui/system"
 import { useQuery } from "@tanstack/react-query"
 import { formatIsoNearestHour, getTodaysDate } from "utils/common"
-import { ForecastDataHourly, getOpenMeteoForecastHourly } from ".."
+import { ForecastDataHourly, getForecastHourly } from ".."
 import { Spot } from "./types"
 import { Loading } from "components"
 import { Link } from 'react-router-dom';
@@ -11,7 +11,7 @@ import { Link } from 'react-router-dom';
 export default function SpotSummary (props: Spot) {
   const {latitude, longitude, name, subregion_name, id} = props
 
-  const {data, isLoading: isHourlyForecastLoading } = useQuery(['forecast_hourly', id], () => getOpenMeteoForecastHourly({
+  const {data, isLoading: isHourlyForecastLoading } = useQuery(['forecast_hourly', id], () => getForecastHourly({
     latitude: latitude,
     longitude: longitude,
     start_date: getTodaysDate(),

--- a/src/features/weather/components/current_weather.tsx
+++ b/src/features/weather/components/current_weather.tsx
@@ -23,9 +23,9 @@ export const CurrentWeather = (props: CurrentWeatherProps) => {
         <Item key={i} sx={{textAlign: {xs: 'center'}}}>
           <Stack direction="column" spacing={1} justifyContent="center">
             <Typography>{time.startPeriodName[i]}</Typography>
-            <Typography variant="h4">{data.temperature[i] ? data.temperature[i] : 'N/A'}{data.temperature[i] && (<>&#8457;</>)}</Typography>
+            <Typography variant="h4">{data.temperature[i] ? data.temperature[i] : '--'}{data.temperature[i] && (<>&#8457;</>)}</Typography>
           </Stack>
-          <Typography sx={{marginBottom: "2px"}}>{data.text[i]? data.text[i] : 'N/A'}</Typography>
+          <Typography sx={{marginBottom: "2px"}}>{data.text[i]? data.text[i] : '--'}</Typography>
         </Item>
       )
     }

--- a/src/pages/spot.tsx
+++ b/src/pages/spot.tsx
@@ -5,10 +5,8 @@ import { useParams } from "react-router-dom"
 import ErrorPage from "./error"
 import { Item, Loading } from "components"
 import { getClostestTideStation, getDailyTides } from "@features/tides"
-import { getOpenMeteoForecastHourly } from "@features/forecasts"
-import { formatIsoNearestHour } from "utils/common"
+import { getForecastCurrent, getForecastHourly } from "@features/forecasts"
 import { DailyTide } from "@features/tides/components/daily_tide"
-import { CurrentHourForecast } from "@features/forecasts/components/current_hour_forecast"
 import { isEmpty } from "lodash"
 import WaveChart from "@features/charts/wave-height"
 import MapBoxSingle from "@features/maps/mapbox/single-instance"
@@ -16,6 +14,7 @@ import { CurrentWeather } from "@features/weather/components/current_weather"
 import { getCurrentWeather } from "@features/weather/api"
 import { NearbyBuoys } from "@features/locations/nearby-buoys"
 import { NoData } from "@features/cards/no_data"
+import { CurrentForecast } from "@features/forecasts/components/current_forecast"
 
 const SpotPage = () => {
   const params = useParams()
@@ -34,7 +33,7 @@ const SpotPage = () => {
     enabled: !!tideStationData?.station_id
   })
 
-  const {data: forecastDataHourly, isLoading: isHourlyForecastLoading } = useQuery(['forecast_hourly'], () => getOpenMeteoForecastHourly({
+  const {data: forecastDataHourly, isLoading: isHourlyForecastLoading } = useQuery(['forecast_hourly'], () => getForecastHourly({
     latitude: spot!.latitude,
     longitude: spot!.longitude,
     forecast_days: 1,
@@ -42,11 +41,16 @@ const SpotPage = () => {
     enabled: !!spot?.name
   })
 
-  const {data: currentWeather, isLoading: isWeatherLoading} = useQuery(['current_weather'], () => getCurrentWeather({lat: spot!.latitude, lng: spot!.longitude}), {
+  const {data: forecastCurrent} = useQuery(['forecast_current'], () => getForecastCurrent({
+    latitude: spot!.latitude,
+    longitude: spot!.longitude,
+  }), {
     enabled: !!spot?.name
   })
 
-  const forecastStartingIndex = forecastDataHourly?.hourly.time.findIndex((item: string) => item === formatIsoNearestHour(spot?.timezone))
+  const {data: currentWeather, isLoading: isWeatherLoading} = useQuery(['current_weather'], () => getCurrentWeather({lat: spot!.latitude, lng: spot!.longitude}), {
+    enabled: !!spot?.name
+  })
 
   return (
     <>
@@ -80,7 +84,7 @@ const SpotPage = () => {
               <Grid item xs={12} sm={12} md={3} lg={3}>
                 <h2>Current conditions</h2>
                 { isHourlyForecastLoading && (<Loading />)}
-                {forecastDataHourly && forecastStartingIndex ? (<CurrentHourForecast forecast={forecastDataHourly} idx={forecastStartingIndex} />) : (<NoData />)}
+                {forecastCurrent ? (<CurrentForecast forecast={forecastCurrent} />) : <NoData />}
               </Grid>
 
               <Grid item xs={12} sm={12} md={3} lg={3}>


### PR DESCRIPTION
Added a function to call the current forecast endpoint: `{{URL}}api/v1/forecast?latitude=36.97&longitude=-122.03&timezone=America/Los_Angeles&current=swell_wave_height,swell_wave_direction,swell_wave_period`

Much simpler than using the hourly dataset. We still use the hourly set for charts but may remove that entirely in the future in favor of something more useful (maps,  pics, etc).