### PR TITLE
Adding slug urls to app

### DIFF
--- a/src/features/locations/api/locations.ts
+++ b/src/features/locations/api/locations.ts
@@ -60,6 +60,17 @@ export const getSurfSpot = async (id: string | number | undefined): Promise<Spot
   
 }
 
+export const getSurfSpotBySlug = async (slug: string | undefined): Promise<Spot> => {
+  return axios.get(`${API_ROUTES.SURF_SPOTS_SLUG}/${slug}`)
+    .then((response) => {
+      return response.data
+    })
+    .catch((error) => {
+      console.error('Failed to fetch spot by slug:', error);
+      throw error;
+    })
+}
+
 export const getSurfSpotClosest = async (lat: number, lng: number): Promise<Spot[]> => {
   return axios.get(`${API_ROUTES.SURF_SPOTS}/find_closest`, {
     params: {

--- a/src/features/locations/types/index.d.ts
+++ b/src/features/locations/types/index.d.ts
@@ -1,6 +1,7 @@
 export interface Spot {
   id: number;
   name: string;
+  slug: string;
   latitude: number;
   longitude: number;
   active: boolean;

--- a/src/pages/spot.tsx
+++ b/src/pages/spot.tsx
@@ -1,4 +1,4 @@
-import { getSurfSpot } from "@features/locations/api/locations"
+import { getSurfSpotBySlug } from "@features/locations/api/locations"
 import { Box, Container, Grid, Stack } from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
 import { useParams } from "react-router-dom"
@@ -22,7 +22,7 @@ const SpotPage = () => {
 
   const {data: spot, isError, error} = useQuery(
     ['spots', spotId],
-    () => getSurfSpot(spotId)
+    () => getSurfSpotBySlug(spotId)
   )
 
   const {data: tideStationData} = useQuery(['tide_station'], () => getClostestTideStation({lat: spot?.latitude, lng: spot?.longitude}), {
@@ -60,7 +60,7 @@ const SpotPage = () => {
             title={`${spot.name} Surf Spot - Surfe Diem`}
             description={`Get current surf conditions, forecasts, and tide information for ${spot.name} in ${spot.subregion_name}. Real-time surf data and weather.`}
             keywords={`${spot.name} surf spot, ${spot.subregion_name} surf, ${spot.name} surf conditions, ${spot.name} surf forecast, ${spot.subregion_name} surf spots`}
-            url={`https://surfe-diem.com/spot/${spot.id}`}
+            url={`https://surfe-diem.com/spot/${spot.slug}`}
           />
           <SurfSpotStructuredData
             name={spot.name}
@@ -69,7 +69,7 @@ const SpotPage = () => {
             longitude={spot.longitude}
             subregion={spot.subregion_name}
             timezone={spot.timezone}
-            url={`https://surfe-diem.com/spot/${spot.id}`}
+            url={`https://surfe-diem.com/spot/${spot.slug}`}
           />
         </>
       )}

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -12,6 +12,7 @@ export const API_ROUTES = {
   TIDES_CLOSEST_STATION_URL: `${API_PREFIX}/tides/find_closest`,
   LOCATIONS_GEOJSON: `${API_PREFIX}/locations/geojson`,
   SURF_SPOTS: `${API_PREFIX}/spots`,
+  SURF_SPOTS_SLUG: `${API_PREFIX}/spots/slug`,
   SURF_SPOTS_GEOJSON: `${API_PREFIX}/spots/geojson`,
   SEARCH: `${API_PREFIX}/search`,
   WEATHER: `${API_PREFIX}/weather`,
@@ -21,4 +22,6 @@ export const API_ROUTES = {
 // Helpers
 export const goToBuoyPage = (location_id: string) => {return `/location/${location_id}`}
 
-export const goToSpotPage = (spot_id: string) => { return `/spot/${spot_id}`}
+export const goToSpotPage = (spot_id: string | number, slug: string) => { 
+  return `/spot/${slug}`
+}


### PR DESCRIPTION
Utilizing the slugs provided by the API for better urls:

1. All spot URLs now use slugs: /spot/privates
2. No more mixed ID/slug URLs
3. Clean, SEO-friendly URLs everywhere