### PR TITLE
add closest spots page, UI fixes

### DIFF
--- a/src/components/common/__tests__/temperature-card.test.tsx
+++ b/src/components/common/__tests__/temperature-card.test.tsx
@@ -36,14 +36,14 @@ describe('TemperatureCard', () => {
     expect(screen.queryByText(/Rash Guard/)).not.toBeInTheDocument();
   });
 
-  it('should display quality description chip', () => {
+  it.skip('should display quality description chip', () => {
     render(<TemperatureCard temperature={20} />);
     
     // Should display quality description (Warm for 20°C)
     expect(screen.getByText('Warm')).toBeInTheDocument();
   });
 
-  it('should handle different temperature values', () => {
+  it.skip('should handle different temperature values', () => {
     const { rerender } = render(<TemperatureCard temperature={5} />);
     expect(screen.getByText('41.0°F')).toBeInTheDocument();
     expect(screen.getByText('Very Cold')).toBeInTheDocument();

--- a/src/components/common/temperature-card.tsx
+++ b/src/components/common/temperature-card.tsx
@@ -14,7 +14,6 @@ const TemperatureCard: React.FC<TemperatureCardProps> = ({
   showComfortLevel = true
 }) => {
   const tempColor = getWaterTempColor(temperature);
-  const qualityDescription = getWaterTempQualityDescription(temperature);
   const comfortLevel = getWaterTempComfortLevel(temperature);
   
   // Format temperature
@@ -107,18 +106,6 @@ const TemperatureCard: React.FC<TemperatureCardProps> = ({
         {showFahrenheit ? formatTemp(temperature, 'C') : formatTemp(temperature, 'F')}
         {showComfortLevel && ` • ${comfortLevel}`}
       </Typography>
-
-      {/* Quality chip */}
-      <Chip 
-        label={qualityDescription}
-        color={tempColor}
-        size="small"
-        sx={{ 
-          fontWeight: 'bold',
-          fontSize: '0.75rem',
-          height: 24
-        }}
-      />
 
       {/* Subtle background pattern */}
       <Box

--- a/src/pages/dashboard-home.tsx
+++ b/src/pages/dashboard-home.tsx
@@ -169,7 +169,7 @@ const DashboardHome = () => {
         navigate('/spots');
         break;
       case 'near_me':
-        // Handle spots near me
+        navigate('/nearby-spots');
         break;
     }
   };
@@ -317,6 +317,59 @@ const DashboardHome = () => {
             </Typography>
             </Box>
           </Box>
+        </Item>
+
+        {/* Quick Actions */}
+        <Item sx={{ bgcolor: 'background.default', marginBottom: "20px", p: 3 }}>
+          <Typography variant="h5" component="h2" sx={{ mb: 2, fontWeight: 600 }}>
+            Quick Actions
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <Button 
+              variant="outlined" 
+              size="large"
+              onClick={() => handleQuickAction('map')}
+              sx={{ 
+                flex: 1,
+                transition: 'all 0.2s ease-in-out',
+                '&:hover': {
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+                }
+              }}
+            >
+              View Map
+            </Button>
+            <Button 
+              variant="outlined" 
+              size="large"
+              onClick={() => handleQuickAction('spots')}
+              sx={{ 
+                flex: 1,
+                transition: 'all 0.2s ease-in-out',
+                '&:hover': {
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                }
+              }}
+            >
+              Browse All Spots
+            </Button>
+            {geolocation && (
+              <Button 
+                variant="outlined" 
+                size="large"
+                onClick={() => handleQuickAction('near_me')}
+                sx={{ 
+                  flex: 1,
+                  transition: 'all 0.2s ease-in-out',
+                  '&:hover': {
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                  }
+                }}
+              >
+                Spots Near Me
+              </Button>
+            )}
+          </Stack>
         </Item>
 
         {/* My Lineup (Favorites) - First row of content */}
@@ -925,13 +978,9 @@ const DashboardHome = () => {
                         <TemperatureCard 
                           temperature={currentWaterTempData.temperature}
                           showFahrenheit={true}
-                          showComfortLevel={true}
+                          showComfortLevel={false}
                         />
                       </Box>
-                      
-                      <Typography variant="body2" color="text.secondary">
-                        {getWaterTempQualityDescription(currentWaterTempData.temperature)} water • {getWaterTempComfortLevel(currentWaterTempData.temperature)}
-                      </Typography>
                     </>
                   )}
                 </CardContent>
@@ -1021,61 +1070,6 @@ const DashboardHome = () => {
             </Grid>
           </Grid>
         </Item>
-
-        {/* Quick Actions */}
-        <Item sx={{ bgcolor: 'background.default', marginBottom: "20px", p: 3 }}>
-          <Typography variant="h5" component="h2" sx={{ mb: 2, fontWeight: 600 }}>
-            Quick Actions
-          </Typography>
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-            <Button 
-              variant="contained" 
-              size="large"
-              onClick={() => handleQuickAction('map')}
-              sx={{ 
-                flex: 1,
-                transition: 'all 0.2s ease-in-out',
-                '&:hover': {
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-                }
-              }}
-            >
-              View Map
-            </Button>
-            <Button 
-              variant="outlined" 
-              size="large"
-              onClick={() => handleQuickAction('spots')}
-              sx={{ 
-                flex: 1,
-                transition: 'all 0.2s ease-in-out',
-                '&:hover': {
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
-                }
-              }}
-            >
-              Browse All Spots
-            </Button>
-            {geolocation && (
-              <Button 
-                variant="outlined" 
-                size="large"
-                onClick={() => handleQuickAction('near_me')}
-                sx={{ 
-                  flex: 1,
-                  transition: 'all 0.2s ease-in-out',
-                  '&:hover': {
-                    boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
-                  }
-                }}
-              >
-                Spots Near Me
-              </Button>
-            )}
-          </Stack>
-        </Item>
-
-
 
         {/* Search Sections (Collapsible) */}
         <Item sx={{ bgcolor: 'background.default', marginTop: "20px" }}>

--- a/src/pages/discovery-home.tsx
+++ b/src/pages/discovery-home.tsx
@@ -83,7 +83,7 @@ const DiscoveryHome = () => {
         navigate('/map');
         break;
       case 'near_me':
-        // Handle spots near me
+        navigate('/nearby-spots');
         break;
     }
   };

--- a/src/pages/nearby-spots.tsx
+++ b/src/pages/nearby-spots.tsx
@@ -1,0 +1,266 @@
+import { Box, Container, Grid, Typography, Card, CardContent, Button, LinearProgress } from "@mui/material";
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { getGeolocation } from "utils/geolocation";
+import { getSurfSpotClosest, getBatchForecast } from "@features/locations/api/locations";
+import { SEO, Loading } from "components";
+import { getWaveHeightColor } from "utils/conditions";
+import { getSwellDirectionText, formatSwellHeight, formatSwellPeriod } from "utils/swell";
+import { formatWaterTemp } from "utils/water-temp";
+import { trackPageView, trackInteraction } from "utils/analytics";
+import { useEffect } from "react";
+import heroImageJpeg from '../assets/manresa1.jpg';
+
+const NearbySpotsPage = () => {
+  const navigate = useNavigate();
+  
+  // Track page view on mount
+  useEffect(() => {
+    trackPageView('nearby-spots', 'nearby-spots');
+  }, []);
+  
+  // Get user's geolocation
+  const {data: geolocation, isPending: geolocationLoading} = useQuery({
+    queryKey: ['geolocation'],
+    queryFn: async () => getGeolocation()
+  });
+
+  // Get closest spots to user's geolocation
+  const {data: closestSpots, isPending: spotsLoading} = useQuery({
+    queryKey: ['closest_spots', geolocation?.latitude, geolocation?.longitude],
+    queryFn: () => getSurfSpotClosest(geolocation!.latitude, geolocation!.longitude),
+    enabled: !!geolocation?.latitude && !!geolocation?.longitude,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  // Get batch forecast data for all closest spots
+  const {data: batchForecastData, isPending: forecastLoading} = useQuery({
+    queryKey: ['nearby_spots_forecast', closestSpots?.slice(0, 10).map(s => s.id).join(',')],
+    queryFn: () => {
+      if (!closestSpots || closestSpots.length === 0) return { spots: [] };
+      
+      const spotIds = closestSpots.slice(0, 10).map(spot => Number(spot.id));
+      return getBatchForecast({
+        spot_ids: spotIds,
+      });
+    },
+    enabled: !!closestSpots && closestSpots.length > 0,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  const handleSpotClick = (spot: any) => {
+    trackInteraction('nearby-spots', 'spot_click', { spot_id: spot.id, spot_name: spot.name });
+    if (spot.slug) {
+      navigate(`/spot/${spot.slug}`);
+    } else {
+      navigate(`/spot/${spot.id}`);
+    }
+  };
+
+  const isLoading = geolocationLoading || spotsLoading || forecastLoading;
+
+  return (
+    <>
+      <SEO 
+        title="Nearby Surf Spots - Surfe Diem"
+        description="Discover the closest surf spots to your location with current conditions and forecasts."
+        keywords="nearby surf spots, local surf spots, surf spots near me, surf conditions"
+        url="https://surfe-diem.com/nearby-spots"
+      />
+      
+      {/* Hero Section */}
+      <Box
+        sx={{
+          backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url(${heroImageJpeg})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
+          height: '400px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'white',
+          textAlign: 'center',
+          position: 'relative'
+        }}
+      >
+        <Container maxWidth="lg">
+          <Typography variant="h2" component="h1" sx={{ fontWeight: 'bold', mb: 2 }}>
+            Nearby Surf Spots
+          </Typography>
+          <Typography variant="h5" sx={{ mb: 3, opacity: 0.9 }}>
+            Discover the best waves closest to you
+          </Typography>
+          {geolocationLoading && (
+            <Typography variant="body1" sx={{ opacity: 0.8 }}>
+              Getting your location...
+            </Typography>
+          )}
+          {geolocation && (
+            <Typography variant="body1" sx={{ opacity: 0.8 }}>
+              Showing spots near your location
+            </Typography>
+          )}
+        </Container>
+      </Box>
+
+      {/* Content Section */}
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        {isLoading ? (
+          <Box sx={{ textAlign: 'center', py: 4 }}>
+            <Loading />
+            <Typography variant="body1" sx={{ mt: 2 }}>
+              Finding surf spots near you...
+            </Typography>
+          </Box>
+        ) : !geolocation ? (
+          <Box sx={{ textAlign: 'center', py: 4 }}>
+            <Typography variant="h5" sx={{ mb: 2 }}>
+              Location Access Required!
+            </Typography>
+            <Typography variant="body1" sx={{ mb: 3 }}>
+              Please enable location access to see nearby surf spots.
+            </Typography>
+            <Button 
+              variant="contained" 
+              onClick={() => window.location.reload()}
+              sx={{ mr: 2 }}
+            >
+              Try Again
+            </Button>
+          </Box>
+        ) : !closestSpots || closestSpots.length === 0 ? (
+          <Box sx={{ textAlign: 'center', py: 4 }}>
+            <Typography variant="h5" sx={{ mb: 2 }}>
+              No Spots Found
+            </Typography>
+            <Typography variant="body1">
+              No surf spots found near your location.
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            <Typography variant="h4" component="h2" sx={{ mb: 3, fontWeight: 'bold' }}>
+              Closest Surf Spots
+            </Typography>
+            
+            <Grid container spacing={3}>
+              {batchForecastData?.spots?.map((spot) => {
+                const swellData = spot.weather?.swell;
+                const waterTempData = spot.weather?.current?.sea_surface_temperature;
+                
+                return (
+                  <Grid item xs={12} sm={6} md={4} lg={3} key={spot.id}>
+                    <Card 
+                      sx={{ 
+                        height: '100%',
+                        cursor: 'pointer',
+                        bgcolor: 'background.default',
+                        transition: 'all 0.2s ease-in-out',
+                        boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+                        '&:hover': {
+                          bgcolor: 'rgba(30, 214, 230, 0.05)',
+                          transform: 'translateY(-2px)',
+                          boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+                        }
+                      }}
+                      onClick={() => handleSpotClick(spot)}
+                    >
+                      <CardContent>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
+                          <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold' }}>
+                            {spot.name}
+                          </Typography>
+                        </Box>
+
+                        {swellData && (
+                          <Box sx={{ mb: 2 }}>
+                            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                              <Typography variant="body2" color="text.secondary">
+                                Wave Height
+                              </Typography>
+                              <Typography variant="h4" sx={{ fontWeight: 'bold' }}>
+                                {formatSwellHeight(swellData.height)}
+                              </Typography>
+                            </Box>
+                            <LinearProgress 
+                              variant="determinate" 
+                              value={Math.min((swellData.height / 8) * 100, 100)}
+                              sx={{ 
+                                height: 4, 
+                                borderRadius: 2,
+                                backgroundColor: 'rgba(0,0,0,0.1)',
+                                '& .MuiLinearProgress-bar': {
+                                  backgroundColor: getWaveHeightColor(swellData.height)
+                                }
+                              }}
+                            />
+                          </Box>
+                        )}
+
+                        {swellData && (
+                          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                            <Typography variant="body2" color="text.secondary">
+                              Period
+                            </Typography>
+                            <Typography variant="body2">
+                              {formatSwellPeriod(swellData.period)}
+                            </Typography>
+                          </Box>
+                        )}
+
+                        {swellData && (
+                          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                            <Typography variant="body2" color="text.secondary">
+                              Direction
+                            </Typography>
+                            <Typography variant="body2">
+                              {getSwellDirectionText(swellData.direction)}
+                            </Typography>
+                          </Box>
+                        )}
+
+                        {waterTempData && (
+                          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                            <Typography variant="body2" color="text.secondary">
+                              Water Temp
+                            </Typography>
+                            <Typography variant="body2">
+                              {formatWaterTemp(waterTempData)}
+                            </Typography>
+                          </Box>
+                        )}
+
+                        {spot.weather?.current?.wind_wave_height && (
+                          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+                            <Typography variant="body2" color="text.secondary">
+                              Wind
+                            </Typography>
+                            <Typography variant="body2">
+                              {spot.weather.current.wind_wave_height.toFixed(1)}
+                            </Typography>
+                          </Box>
+                        )}
+
+                        <Button 
+                          variant="outlined" 
+                          size="small" 
+                          fullWidth
+                          sx={{ mt: 'auto' }}
+                        >
+                          View Details
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  </Grid>
+                );
+              })}
+            </Grid>
+          </>
+        )}
+      </Container>
+    </>
+  );
+};
+
+export default NearbySpotsPage; 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,6 +9,7 @@ import { AppWrapper } from "./wrapper";
 import SpotPage from "pages/spot";
 import SurfSpotsPage from "pages/spots";
 import AboutPage from "pages/about";
+import NearbySpotsPage from "pages/nearby-spots";
 
 const isMaintenanceMode = MAINTENANCE_MODE === 'true' ? true : false;
 
@@ -46,6 +47,10 @@ export const router = createBrowserRouter([
           {
             path: "about",
             element: <AboutPage />,
+          },
+          {
+            path: "nearby-spots",
+            element: <NearbySpotsPage />,
           }
         ]
       }    ]);

--- a/src/utils/__tests__/water-temp.test.ts
+++ b/src/utils/__tests__/water-temp.test.ts
@@ -149,7 +149,7 @@ describe('Water Temperature Utilities', () => {
     it('should return correct comfort levels for different temperatures', () => {
       expect(getWaterTempComfortLevel(5)).toBe('Wetsuit Required');
       expect(getWaterTempComfortLevel(12)).toBe('Full Wetsuit');
-      expect(getWaterTempComfortLevel(17)).toBe('Spring Suit');
+      expect(getWaterTempComfortLevel(17)).toBe('Spring Suit or Full Wetsuit');
       expect(getWaterTempComfortLevel(22)).toBe('Rash Guard');
       expect(getWaterTempComfortLevel(27)).toBe('Board Shorts');
       expect(getWaterTempComfortLevel(35)).toBe('Board Shorts');
@@ -157,7 +157,7 @@ describe('Water Temperature Utilities', () => {
 
     it('should handle boundary values', () => {
       expect(getWaterTempComfortLevel(10)).toBe('Full Wetsuit');
-      expect(getWaterTempComfortLevel(15)).toBe('Spring Suit');
+      expect(getWaterTempComfortLevel(15)).toBe('Spring Suit or Full Wetsuit');
       expect(getWaterTempComfortLevel(20)).toBe('Rash Guard');
       expect(getWaterTempComfortLevel(25)).toBe('Board Shorts');
       expect(getWaterTempComfortLevel(30)).toBe('Board Shorts');


### PR DESCRIPTION
Tide System Updates
✅ Integrated new `getCurrentTides` API endpoint for dashboard
✅ Updated tide data structure to handle array format from API
✅ Implemented GMT to local timezone conversion for tide times
✅ Simplified tide logic to use last array index (chronological order)
✅ Updated daily tide API to handle GMT time conversion

New Nearby Spots Page
✅ Created /nearby-spots page with hero image and grid layout
✅ Integrated geolocation + closest spots + batch forecast APIs
✅ Displays 10 closest spots with abbreviated forecast data
✅ Click navigation to individual spot pages
✅ Added routing and wired up "nearby" quick action buttons